### PR TITLE
Add LemonCake to Payments & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Tools and platforms for using stablecoins in real-world transactions.
 - [BitPay](https://bitpay.com/) — Payment processor supporting stablecoin transactions and cards.
 - [MoonPay](https://www.moonpay.com/) — On-ramp and off-ramp infrastructure for fiat and crypto.
 - [Ramp](https://ramp.network/) — Payment infrastructure connecting fiat and stablecoins.
+- [LemonCake](https://lemoncake.xyz) — USDC Pay Tokens for AI agents, with hard spending caps, sub-second kill-switch, and automatic journaling into freee / Money Forward / QuickBooks.
 
 ## Analytics & Data
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Tools and platforms for using stablecoins in real-world transactions.
 - [BitPay](https://bitpay.com/) — Payment processor supporting stablecoin transactions and cards.
 - [MoonPay](https://www.moonpay.com/) — On-ramp and off-ramp infrastructure for fiat and crypto.
 - [Ramp](https://ramp.network/) — Payment infrastructure connecting fiat and stablecoins.
-- [LemonCake](https://lemoncake.xyz) — USDC Pay Tokens for AI agents, with hard spending caps, sub-second kill-switch, and automatic journaling into freee / Money Forward / QuickBooks.
+- [LemonCake](https://lemoncake.xyz?utm_source=awesome-stablecoins&utm_medium=github) — USDC Pay Tokens for AI agents, with hard spending caps, sub-second kill-switch, and automatic journaling into freee / Money Forward / QuickBooks.
 
 ## Analytics & Data
 


### PR DESCRIPTION
Adds [LemonCake](https://lemoncake.xyz) to the **Payments & Integrations** section.

USDC Pay Tokens for AI agents — JWT-signed upstream API payment proxy with hard spending caps, expiry, domain scope, and a sub-second kill-switch. Every settled call is auto-journaled into freee / Money Forward (Japanese accounting) or QuickBooks. Settles in USDC on Base.

Thanks for maintaining this list!