### PR TITLE
Add Awesome Crypto Cards under Payments & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Tools and platforms for using stablecoins in real-world transactions.
 - [BitPay](https://bitpay.com/) — Payment processor supporting stablecoin transactions and cards.
 - [MoonPay](https://www.moonpay.com/) — On-ramp and off-ramp infrastructure for fiat and crypto.
 - [Ramp](https://ramp.network/) — Payment infrastructure connecting fiat and stablecoins.
+- [Awesome Crypto Cards](https://github.com/mbtrilla/awesome-crypto-cards) — Curated list of 136 crypto debit and credit cards, including 85 that fund directly from USDC/USDT balances.
 
 ## Analytics & Data
 


### PR DESCRIPTION
Submitting [awesome-crypto-cards](https://github.com/mbtrilla/awesome-crypto-cards) as a Payments & Integrations entry, since 85 of the 136 cards in the list are funded directly from USDC/USDT balances (Ether.fi Cash, Gnosis Pay, Bleap, Coinbase Card, etc.).

## Why it fits this list

The Payments section already includes BitPay (which has its own card) and Ramp (fiat→stablecoin onramp). Cards are arguably the most consumer-visible stablecoin payment integration: every swipe is a stablecoin → fiat conversion at the merchant.

The list itself groups cards by:
- Stablecoin support (USDC, USDT, DAI on most cards)
- Custody (self-custody pulls from your wallet on-chain)
- Region availability

## Quality signals

- MIT licensed, awesome-lint --no-emoji clean (CI runs on every push)
- "Shipping products only" rule — no roadmap entries
- Maintained: list reflects issuer changes (Binance Visa pulled Dec 2023, Crypto.com cashback drop, etc.)

Happy to adjust phrasing or move to a different section if it doesn't fit.