### PR TITLE
Add Sharpe Stablecoins to analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Platforms for tracking stablecoin supply, flows, and market behavior.
 - [Dune](https://dune.com/) — Query-based analytics platform for blockchain data.
 - [Token Terminal](https://tokenterminal.com/) — Financial metrics and analytics for crypto assets.
 - [CoinGecko](https://www.coingecko.com/) — Market data and stablecoin tracking.
+- [Sharpe Stablecoins](https://www.sharpe.ai/stablecoins) — Stablecoin analytics for market cap, peg deviation, supply by chain, mechanisms, and yield views.
 
 ## Regulation & Compliance
 


### PR DESCRIPTION
## Thank you for your contribution!

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows the quality and content standards.
- [x] I have not added multiple links to promote a single source.

### Description of the Change

Adds Sharpe Stablecoins to Analytics & Data. This is a stablecoin-specific tracker, so the entry links directly to the stablecoin page and describes the stablecoin metrics rather than the broader Sharpe terminal.

Website URL: https://www.sharpe.ai/stablecoins
Validation: `git diff --check` passes.
Linear: SHA-157

### Additional Notes

Disclosure: I work on Sharpe.