### PR TITLE
Add Pharos to Analytics & Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Platforms for tracking stablecoin supply, flows, and market behavior.
 - [Token Terminal](https://tokenterminal.com/) — Financial metrics and analytics for crypto assets.
 - [CoinGecko](https://www.coingecko.com/) — Market data and stablecoin tracking.
 - [Sharpe Stablecoins](https://www.sharpe.ai/stablecoins) — Stablecoin analytics for market cap, peg deviation, supply by chain, mechanisms, and yield views.
+- [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
 
 ## Regulation & Compliance
 


### PR DESCRIPTION
This PR adds [Pharos](https://pharos.watch/) to the Analytics & Data
section of the stablecoins list.

Pharos is an open-source stablecoin analytics dashboard that covers:
- Peg stress / deviation tracking
- DEX liquidity analysis
- Safety and resilience scores
- Blacklist event monitoring
- Mint/burn flow intelligence
- Historical stablecoin failure data

The entry follows the existing list format and is placed at the end of
the section to match the section's sorting convention.