### PR TITLE
Add Stablesonar - yield radar for DeFi stablecoins

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Platforms for tracking stablecoin supply, flows, and market behavior.
 - [Token Terminal](https://tokenterminal.com/) — Financial metrics and analytics for crypto assets.
 - [CoinGecko](https://www.coingecko.com/) — Market data and stablecoin tracking.
 - [Sharpe Stablecoins](https://www.sharpe.ai/stablecoins) — Stablecoin analytics for market cap, peg deviation, supply by chain, mechanisms, and yield views.
+- [Stablesonar](https://stablesonar.xyz) - Yield radar tracking every stablecoin pool paying ≥10% APY across all major DeFi chains.
 
 ## Regulation & Compliance
 


### PR DESCRIPTION
Hi! Adding Stablesonar — an independent dashboard that tracks stablecoin yield opportunities (USDC, USDT, EURC, DAI and etc) across major DeFi chains.

**Why it fits this list:**
- Focused exclusively on stablecoins
- Aggregates pools paying above 10% APY
- Hourly data refresh
- Each pool tagged with audit / TVL / risk metadata
- Free public dashboard, no signup required

Site: https://stablesonar.xyz
Repo / org: https://github.com/wandercoin

Happy to adjust the line or move it to a different section if you'd prefer.