### PR TITLE
Add OpenSettle to Payments & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Tools and platforms for using stablecoins in real-world transactions.
 - [Stripe Crypto](https://stripe.com/crypto) — Payment infrastructure supporting stablecoin transactions.
 - [Coinbase Commerce](https://commerce.coinbase.com/) — Merchant platform for accepting crypto and stablecoins.
 - [BitPay](https://bitpay.com/) — Payment processor supporting stablecoin transactions and cards.
+- [OpenSettle](https://opensettle.io) — Non-custodial API for accepting USDC and USDT, settling payments directly to the merchant's wallet.
 - [MoonPay](https://www.moonpay.com/) — On-ramp and off-ramp infrastructure for fiat and crypto.
 - [Ramp](https://ramp.network/) — Payment infrastructure connecting fiat and stablecoins.
 


### PR DESCRIPTION
### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [ ] I have not added a link to my own project if it's not notable or widely used.

### Description of the Change

Adds OpenSettle to the **Payments & Integrations** section.

OpenSettle is a non-custodial API for accepting USDC and USDT stablecoin payments, where funds settle directly to the merchant's own wallet — the processor never takes custody, pools funds, or holds a float. That non-custodial design is the main contrast with the custodial options already in this section (Coinbase Commerce, BitPay), so it adds a distinct option rather than a duplicate.

**Disclosure:** I maintain OpenSettle, so I've left the "not my own project unless notable" box unchecked for you to judge — it's early-stage and not yet widely used. Entirely your call on whether it meets the bar; happy to adjust the wording, description, or placement to match your conventions, or to withdraw it if it's too early.

### Additional Notes

Live link returns HTTP 200. Entry matches the section's existing `- [Name](url) — sentence.` format and is placed with the other acceptance processors (after BitPay, before the on/off-ramps).
