### PR TITLE
Add USDCtoFiat to Payments & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Tools and platforms for using stablecoins in real-world transactions.
 - [BitPay](https://bitpay.com/) — Payment processor supporting stablecoin transactions and cards.
 - [MoonPay](https://www.moonpay.com/) — On-ramp and off-ramp infrastructure for fiat and crypto.
 - [Ramp](https://ramp.network/) — Payment infrastructure connecting fiat and stablecoins.
+- [USDCtoFiat](https://usdctofiat.xyz/) — Non-custodial USDC-to-fiat cash-out on Base into Venmo, Cash App, Revolut, and other payment apps, with a public TypeScript SDK.
 
 ## Analytics & Data
 


### PR DESCRIPTION
## Summary
Adds [USDCtoFiat](https://usdctofiat.xyz/) after Ramp in Payments & Integrations.

USDCtoFiat is a live, non-custodial USDC-to-fiat cash-out on Base (Venmo, Cash App, Revolut, and other payment apps) with a public SDK at [`@usdctofiat/offramp`](https://www.npmjs.com/package/@usdctofiat/offramp).

## Checklist
- [x] Link is active
- [x] Fits Payments & Integrations
- [x] Matches existing one-line format