### PR TITLE
Add Paycoin Index to Analytics & Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Tools and platforms for using stablecoins in real-world transactions.
 
 Platforms for tracking stablecoin supply, flows, and market behavior.
 
+- [Paycoin Index](https://paycoin.com/) — Hourly, source-cited index of stablecoin transfer costs across nine chains; free JSON data and daily history, no key required.
 - [Glassnode](https://glassnode.com/) — On-chain analytics platform for tracking stablecoin flows and metrics.
 - [Nansen](https://www.nansen.ai/) — Blockchain analytics and wallet intelligence platform.
 - [Dune](https://dune.com/) — Query-based analytics platform for blockchain data.


### PR DESCRIPTION
Adds the Paycoin Index to the **Analytics & Data** section: an automated, open-methodology index of what it costs to move value on stablecoin rails (USDT/USDC across nine networks), rebuilt hourly. Free JSON at https://paycoin.com/data/latest.json with daily history, documented schema, and per-source provenance. No API key, no token, no affiliation with any project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)